### PR TITLE
Add support for asynch notifications on a file-descriptor

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {port_sources, ["c_src/procket.c"]}.
 {port_envs, [
-    {"LDFLAGS", "$LDFLAGS -Lc_src -lancillary"}
+    {"LDFLAGS", "$LDFLAGS -Lc_src -lancillary -lev"}
     ]}.
 
 {port_pre_script, {"make -C c_src -f Makefile.ancillary -f Makefile.cmd", ""}}.

--- a/src/procket.erl
+++ b/src/procket.erl
@@ -51,6 +51,10 @@
         buf/1,
         memcpy/2,
 
+ 	    watcher_create/3,
+	    watcher_arm/1,
+	    watcher_disarm/1,
+
         errno_id/1
     ]).
 -export([
@@ -123,6 +127,13 @@ alloc(_) ->
 buf(_) ->
     erlang:error(not_implemented).
 memcpy(_,_) ->
+    erlang:error(not_implemented).
+
+watcher_create(_,_,_) ->
+    erlang:error(not_implemented).
+watcher_arm(_) ->
+    erlang:error(not_implemented).
+watcher_disarm(_) ->
     erlang:error(not_implemented).
 
 sendto(Socket, Buf) ->


### PR DESCRIPTION
This patch uses libev inside the NIF framework to provide a mechanism
for monitoring one or more file-descriptors for changes.

It introduces three more verbs to the procket namespace:

{ok, Handle} = procket:watcher_create(Fd, Flags, Cookie)
procket:watcher_arm(Handle)
procket:watcher_disarm(Handle)

The idea is that watcher_create takes an Fd, and a set of flags (0x1 for
READ, 0x2 for WRITE, 0x3 for READ/WRITE), and an arbitrary term (Cookie).

When the FD becomes ready for either a READ or WRITE, it will fire a msg
{procket_watcher, Flags, Cookie} back at the caller and disarm itself.

The user may subsequently re-arm the trigger with procket:watcher_arm()
and disarm it with procket:watcher_disarm().

Signed-off-by: Gregory Haskins ghaskins@novell.com
