### PR TITLE
adding empty applications parameter

### DIFF
--- a/src/procket.app.src
+++ b/src/procket.app.src
@@ -1,4 +1,4 @@
 {application, procket,
     [{description, "Low level socket operations"},
-     {applications, []},
+     {applications, [crypto]},
      {vsn, "0.4.4"}]}.

--- a/src/procket_mktmp.erl
+++ b/src/procket_mktmp.erl
@@ -57,7 +57,6 @@ name(Template) ->
     template(Template, ?ALPHANUM).
 
 template(Name, Chars) ->
-    crypto:start(),
     template(lists:reverse(Name), [], Chars).
 template([$X|Rest], Acc, Chars) ->
     template(Rest,


### PR DESCRIPTION
`relx` needs an explicitly stated applications parameter in .app file to successfully generate releases.

I also removed the line that explicitly started crypto in `src/procket_mktmp.erl` and added crypto to applications in procket.app so otp would automatically detect dependency and start crypto.
