### PR TITLE
Make sendmsg and recvmsg actually usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,22 @@ procket works with any version of Erlang after R14A.
 
         See recv(2).
 
+    recvmsg(Socket, Size, CtrlDataSize, Flags) -> {ok, Buf, Sockaddr, CtrlData, Flags} |
+                                                  {error, posix()}
+
+        Types   Socket = integer()
+                Size = ulong()
+                CtrlDataSize = ulong()
+                Flags = integer()
+                Buf = binary()
+                Sockaddr = binary()
+                CtrlData = [{integer(), integer(), binary()}]
+
+        See recvmsg(2) and cmsg(3).
+
+        The control data, if any, is returned as a list of 3-tuples consisting of the cmsg
+        level, type and data fields.
+
     sendto(Socket, Buf) -> ok | {error, posix()}
     sendto(Socket, Buf, Flags) -> ok | {error, posix()}
     sendto(Socket, Buf, Flags, Sockaddr) -> ok | {error, posix()}
@@ -164,6 +180,21 @@ procket works with any version of Erlang after R14A.
                 Sockaddr = binary()
 
         See sendto(2).
+
+    sendmsg(Socket, Buf, Flags, Sockaddr, CtrlData) -> ok | {error, posix()}
+
+        Types   Socket = integer()
+                Size = ulong()
+                CtrlDataSize = ulong()
+                Flags = integer()
+                Buf = binary()
+                Sockaddr = binary()
+                CtrlData = [{integer(), integer(), binary()}]
+
+        See sendmsg(2) and cmsg(3).
+
+        The control data, if any, is sent as a list of 3-tuples consisting of the cmsg
+        level, type and data fields.
 
     read(FD, Length) -> {ok, Buf} | {error, posix()}
 

--- a/examples/sendmsg_recvmsg_echo.erl
+++ b/examples/sendmsg_recvmsg_echo.erl
@@ -39,10 +39,16 @@
 start() ->
     {ok, FD} = procket:socket(inet6, dgram, udp),
     %% set IPV6_RECVPKTINFO
-    ok = procket:setsockopt(FD, 41, 49, <<1:32>>),
-    %% bind to :: on port ?PIRT
-    ok = procket:bind(FD, <<10:16/native, ?PORT:16/integer-unsigned-big,
-                            0:192>>),
+    RecvPktInfo = case os:type() of
+        {unix, linux} -> 49;
+        {unix, _} -> 36
+    end,
+    ok = procket:setsockopt(FD, 41, RecvPktInfo, <<1:32>>),
+    Family = procket:family(inet6),
+    io:format("inet family ~p~n", [Family]),
+    %% bind to :: on port ?PORT
+    SA = list_to_binary([procket:sockaddr_common(Family, 28), <<?PORT:16/integer-unsigned-big, 0:192>>]),
+    ok = procket:bind(FD, SA),
     loop(FD).
 
 loop(FD) ->
@@ -51,16 +57,40 @@ loop(FD) ->
     case procket:recvmsg(FD, 512, 512, 0) of
         {error, eagain} ->
             loop(FD);
-        {ok, Buf, From, CtrlData, Flags} ->
+        {ok, Buf, From0, CtrlData, Flags} ->
             io:format("Buffer ~p, From ~p, Ctrldata ~p Flags ~p~n", [Buf,
-                                                                     From,
+                                                                     From0,
                                                                      CtrlData,
                                                                      Flags]),
+            From = fixup_from(From0),
             %% echo the packet back, but set the destination address to the
             %% 'from' of the previous packet, and send the previous message's
             %% control data so that the source address is set to the
             %% destination address of the previous packet
-            procket:sendmsg(FD, Buf, 0, From, CtrlData),
+            ok = procket:sendmsg(FD, Buf, 0, From, fixup_control_data(CtrlData)),
             loop(FD)
     end.
+
+%% on the BSDs, use the 'length' field in the sockaddr_storage field to
+%% trim it to length. FreeBSD throws einval if you pass overlong data as the
+%% destination address to sendmsg.
+fixup_from(From0) ->
+    case erlang:system_info(os_type) of
+        {unix,BSD} when BSD == darwin;
+                BSD == openbsd;
+                BSD == netbsd;
+                BSD == freebsd ->
+            <<Length:8/integer-unsigned,_/binary>> = From0,
+            binary:part(From0, 0, Length);
+        {unix,_} ->
+            From0
+    end.
+
+%% on freebsd, the PKTINFO control data that comes back from recvmsg
+%% is 4 bytes too long. I don't know why.
+fixup_control_data(CData) ->
+    lists:map(fun({41, 46, In6Pktinfo}) ->
+                {41, 46, binary:part(In6Pktinfo, 0, 20)};
+            (E) -> E
+        end, CData).
 

--- a/examples/sendmsg_recvmsg_echo.erl
+++ b/examples/sendmsg_recvmsg_echo.erl
@@ -1,0 +1,66 @@
+%% Copyright (c) 2015, Andrew Thompson <andrew@hijacked.us>
+%% All rights reserved.
+%%
+%% Redistribution and use in source and binary forms, with or without
+%% modification, are permitted provided that the following conditions
+%% are met:
+%%
+%% Redistributions of source code must retain the above copyright
+%% notice, this list of conditions and the following disclaimer.
+%%
+%% Redistributions in binary form must reproduce the above copyright
+%% notice, this list of conditions and the following disclaimer in the
+%% documentation and/or other materials provided with the distribution.
+%%
+%% Neither the name of the author nor the names of its contributors
+%% may be used to endorse or promote products derived from this software
+%% without specific prior written permission.
+%%
+%% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+%% "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+%% LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+%% FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+%% COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+%% INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+%% BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+%% LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+%% CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+%% LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+%% ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+%% POSSIBILITY OF SUCH DAMAGE.
+
+%% procket test client
+-module(sendmsg_recvmsg_echo).
+
+-export([start/0]).
+
+-define(PORT, 2097).
+
+start() ->
+    {ok, FD} = procket:socket(inet6, dgram, udp),
+    %% set IPV6_RECVPKTINFO
+    ok = procket:setsockopt(FD, 41, 49, <<1:32>>),
+    %% bind to :: on port ?PIRT
+    ok = procket:bind(FD, <<10:16/native, ?PORT:16/integer-unsigned-big,
+                            0:192>>),
+    loop(FD).
+
+loop(FD) ->
+    %% recv a packet up to 512 bytes long, along with 512 bytes of control
+    %% data
+    case procket:recvmsg(FD, 512, 512, 0) of
+        {error, eagain} ->
+            loop(FD);
+        {ok, Buf, From, CtrlData, Flags} ->
+            io:format("Buffer ~p, From ~p, Ctrldata ~p Flags ~p~n", [Buf,
+                                                                     From,
+                                                                     CtrlData,
+                                                                     Flags]),
+            %% echo the packet back, but set the destination address to the
+            %% 'from' of the previous packet, and send the previous message's
+            %% control data so that the source address is set to the
+            %% destination address of the previous packet
+            procket:sendmsg(FD, Buf, 0, From, CtrlData),
+            loop(FD)
+    end.
+

--- a/src/procket.erl
+++ b/src/procket.erl
@@ -52,6 +52,8 @@
         recvmsg/4,
         sendmsg/5,
 
+        family/1,
+
         alloc/1,
         buf/1,
         memcpy/2,
@@ -365,7 +367,9 @@ family(inet6) ->
     case os:type() of
         {unix, linux} -> 10;
         {unix, darwin} -> 30;
-        {unix, freebsd} -> 28
+        {unix, freebsd} -> 28;
+        {unix, netbsd} -> 24;
+        {unix, openbsd} -> 24
     end;
 family(netlink) -> 16;
 family(packet) -> 17;

--- a/src/procket.erl
+++ b/src/procket.erl
@@ -49,8 +49,8 @@
         getsockopt/4,
         getsockname/2,
 
-        recvmsg/3,
-        sendmsg/3,
+        recvmsg/4,
+        sendmsg/5,
 
         alloc/1,
         buf/1,
@@ -160,9 +160,9 @@ write_nif(_,_) ->
 writev(_,_) ->
     erlang:nif_error(not_implemented).
 
-recvmsg(_,_,_) ->
+recvmsg(_,_,_,_) ->
     erlang:nif_error(not_implemented).
-sendmsg(_,_,_) ->
+sendmsg(_,_,_,_,_) ->
     erlang:nif_error(not_implemented).
 
 setsockopt(_,_,_,_) ->


### PR DESCRIPTION
Instead of passing in a binary that is treated as the 'msghdr' struct,
pass in data needed to construct an appropriate msghdr struct and also
return useful result data, including the control data.

Documentation and an example are also included.

I've only tested this with linux and with ipv6 right now. I will test the BSDs/Illumos and update the PR if there's any other changes needed.