### PR TITLE
Fix Makefile $(REBAR) variable handling on Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR=$(shell which rebar || echo ./rebar)
+REBAR = $(shell test -e `which rebar` 2>/dev/null && which rebar || echo "./rebar")
 DEPSOLVER_PLT=$(CURDIR)/.depsolver_plt
 
 all: dirs compile
@@ -43,3 +43,5 @@ typer: $(DEPSOLVER_PLT)
 
 distclean: clean
 	@rm $(DEPSOLVER_PLT)
+
+print-%: ; @echo $*=$($*)


### PR DESCRIPTION
On solaris flavors, `which` has sometimes poor behavior of
not returning proper exit codes or printing errors to STDOUT
rather than STDERR.  All of this is to say, the makefile didn't
behave correctly on Solaris. $(REBAR) ended up being set to
"rebar not found" which made the compile target less than happy.

I added a print-* target to test this easier.  Simply
`make print-VAR` to see the value.  So `make print-REBAR`
will show you the value of $REBAR.