### PR TITLE
Application-friendly sockopt interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 deps/
 ebin/
 priv/
+.rebar/

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ procket works with any version of Erlang after R14A.
     setsockopt(Socket, Level, Optname, Optval) -> ok | {error, posix}
 
         Types   Socket = integer()
-                Level = integer()
-                Optname = integer()
+                Level = integer() | atom()
+                Optname = integer() | atom()
                 Optval = binary()
 
         See setsockopt(2).
@@ -241,8 +241,8 @@ procket works with any version of Erlang after R14A.
     getsockopt(Socket, Level, Optname, Optval) -> {ok, Buf} | {error, posix}
 
         Types   Socket = integer()
-                Level = integer()
-                Optname = integer()
+                Level = integer() | atom()
+                Optname = integer() | atom()
                 Optval = binary()
                 Buf = binary()
 

--- a/c_src/procket.c
+++ b/c_src/procket.c
@@ -33,6 +33,7 @@
 #include "erl_driver.h"
 #include "ancillary.h"
 #include "procket.h"
+#include "sockopt.h"
 
 static ERL_NIF_TERM error_tuple(ErlNifEnv *env, int errnum);
 void alloc_free(ErlNifEnv *env, void *obj);
@@ -527,10 +528,58 @@ nif_setsockopt(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
 
     if (!enif_get_int(env, argv[1], &level))
-        return enif_make_badarg(env);
+    {
+        unsigned atom_length;
+        if (enif_get_atom_length(env, argv[1], &atom_length, ERL_NIF_LATIN1))
+        {
+            char *atom_buf = enif_alloc(atom_length);
+            if (enif_get_atom(env, argv[1], atom_buf, atom_length+1, ERL_NIF_LATIN1))
+            {
+                if (!level_lookup(atom_buf, atom_length, &level))
+                {
+                    enif_free(atom_buf);
+                    return enif_make_badarg(env);
+                }
+                enif_free(atom_buf);
+            }
+            else
+            {
+                enif_free(atom_buf);
+                return enif_make_badarg(env);
+            }
+        }
+        else
+        {
+            return enif_make_badarg(env);
+        }
+    }
 
     if (!enif_get_int(env, argv[2], &optname))
-        return enif_make_badarg(env);
+    {
+        unsigned atom_length2;
+        if (enif_get_atom_length(env, argv[2], &atom_length2, ERL_NIF_LATIN1))
+        {
+            char *atom_buf2 = enif_alloc(atom_length2);
+            if (enif_get_atom(env, argv[2], atom_buf2, atom_length2+1, ERL_NIF_LATIN1))
+            {
+                if (!optname_lookup(atom_buf2, atom_length2, &optname))
+                {
+                    enif_free(atom_buf2);
+                    return enif_make_badarg(env);
+                }
+                enif_free(atom_buf2);
+            }
+            else
+            {
+                enif_free(atom_buf2);
+                return enif_make_badarg(env);
+            }
+        }
+        else
+        {
+            return enif_make_badarg(env);
+        }
+    }
 
     if (!enif_inspect_binary(env, argv[3], &optval))
         return enif_make_badarg(env);
@@ -553,15 +602,62 @@ nif_getsockopt(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     ErlNifBinary optval = {0};
     socklen_t optlen = 0;
 
-
     if (!enif_get_int(env, argv[0], &s))
         return enif_make_badarg(env);
 
     if (!enif_get_int(env, argv[1], &level))
-        return enif_make_badarg(env);
+    {
+        unsigned atom_length;
+        if (enif_get_atom_length(env, argv[1], &atom_length, ERL_NIF_LATIN1))
+        {
+            char *atom_buf = enif_alloc(atom_length);
+            if (enif_get_atom(env, argv[1], atom_buf, atom_length+1, ERL_NIF_LATIN1))
+            {
+                if (!level_lookup(atom_buf, atom_length, &level))
+                {
+                    enif_free(atom_buf);
+                    return enif_make_badarg(env);
+                }
+                enif_free(atom_buf);
+            }
+            else
+            {
+                enif_free(atom_buf);
+                return enif_make_badarg(env);
+            }
+        }
+        else
+        {
+            return enif_make_badarg(env);
+        }
+    }
 
     if (!enif_get_int(env, argv[2], &optname))
-        return enif_make_badarg(env);
+    {
+        unsigned atom_length2;
+        if (enif_get_atom_length(env, argv[2], &atom_length2, ERL_NIF_LATIN1))
+        {
+            char *atom_buf2 = enif_alloc(atom_length2);
+            if (enif_get_atom(env, argv[2], atom_buf2, atom_length2+1, ERL_NIF_LATIN1))
+            {
+                if (!optname_lookup(atom_buf2, atom_length2, &optname))
+                {
+                    enif_free(atom_buf2);
+                    return enif_make_badarg(env);
+                }
+                enif_free(atom_buf2);
+            }
+            else
+            {
+                enif_free(atom_buf2);
+                return enif_make_badarg(env);
+            }
+        }
+        else
+        {
+            return enif_make_badarg(env);
+        }
+    }
 
     if (!enif_inspect_binary(env, argv[3], &optval))
         return enif_make_badarg(env);

--- a/c_src/procket.h
+++ b/c_src/procket.h
@@ -68,7 +68,6 @@
 
 extern char *__progname;
 
-
 typedef struct {
     int fdtype;             /* fd type requested */
     char *path;             /* path to pipe file */
@@ -83,5 +82,3 @@ typedef struct {
     int protocol;           /* socket protocol: IPPROTO_TCP */
     int backlog;            /* Listen backlog */
 } PROCKET_STATE;
-
-

--- a/c_src/procket.h
+++ b/c_src/procket.h
@@ -33,6 +33,10 @@
   #define __APPLE_USE_RFC_3542  /* For IPV6_RECVPKTINFO */
 #endif
 
+#ifdef __sun__
+  #define __EXTENSIONS__ /* For IPV6_RECVPKTINFO */
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/c_src/procket.h
+++ b/c_src/procket.h
@@ -29,6 +29,10 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#ifdef __APPLE__
+  #define __APPLE_USE_RFC_3542  /* For IPV6_RECVPKTINFO */
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,7 +43,6 @@
 
 #include <sys/types.h>
 #include <netdb.h>
-
 #include <netinet/in.h>
 #include <sys/un.h>
 #include <sys/socket.h>

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -100,21 +100,25 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_IPIP;
             return 1;
         }
+#ifdef IPPROTO_DCCP
         else if (strncmp("IPPROTO_DCCP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_DCCP;
             return 1;
         }
+#endif
         else if (strncmp("IPPROTO_RSVP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_RSVP;
             return 1;
         }
+#ifdef IPPROTO_COMP
         else if (strncmp("IPPROTO_COMP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_COMP;
             return 1;
         }
+#endif
         else if (strncmp("IPPROTO_SCTP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_SCTP;
@@ -140,6 +144,7 @@ int level_lookup(char *level_name, int level_size, int *level_value)
         }
     }
 #endif
+#ifdef IPPROTO_UDPLITE
     else if (level_size == 15)
     {
         if (strncmp("IPPROTO_UDPLITE", level_name, level_size) == 0)
@@ -148,7 +153,7 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             return 1;
         }
     }
-
+#endif
     *level_value = -1;
     return 0;
 }
@@ -196,46 +201,58 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
     }
     else if (option_size == 11)
     {
+        if (strncmp("SO_SNDTIMEO", option_name, option_size) == 0)
+        {
+            *option_value = SO_SNDTIMEO;
+            return 1;
+        }
+#ifdef SO_PASSCRED
         if (strncmp("SO_PASSCRED", option_name, option_size) == 0)
         {
             *option_value = SO_PASSCRED;
             return 1;
         }
+#endif
+#ifdef SO_PEERCRED
         else if (strncmp("SO_PEERCRED", option_name, option_size) == 0)
         {
             *option_value = SO_PEERCRED;
             return 1;
         }
+#endif
+#ifdef SO_RCVLOAWAT
         else if (strncmp("SO_RCVLOWAT", option_name, option_size) == 0)
         {
             *option_value = SO_RCVLOWAT;
             return 1;
         }
+#endif
+#ifdef SO_SNDLOWAT
         else if (strncmp("SO_SNDLOWAT", option_name, option_size) == 0)
         {
             *option_value = SO_SNDLOWAT;
             return 1;
         }
+#endif
         else if (strncmp("SO_RCVTIMEO", option_name, option_size) == 0)
         {
             *option_value = SO_RCVTIMEO;
             return 1;
         }
-        else if (strncmp("SO_SNDTIMEO", option_name, option_size) == 0)
-        {
-            *option_value = SO_SNDTIMEO;
-            return 1;
-        }
+#ifdef SO_NO_CHECK
         else if (strncmp("SO_NO_CHECK", option_name, option_size) == 0)
         {
             *option_value = SO_NO_CHECK;
             return 1;
         }
+#endif
+#ifdef SO_PRIORITY
         else if (strncmp("SO_PRIORITY", option_name, option_size) == 0)
         {
             *option_value = SO_PRIORITY;
             return 1;
         }
+#endif
     }
     else if (option_size == 12)
     {
@@ -264,11 +281,13 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_OOBINLINE;
             return 1;
         }
+#ifdef SO_BSDCOMPAT
         else if (strncmp("SO_BSDCOMPAT", option_name, option_size) == 0)
         {
             *option_value = SO_BSDCOMPAT;
             return 1;
         }
+#endif
 #ifdef SO_REUSEPORT
         else if (strncmp("SO_REUSEPORT", option_name, option_size) == 0)
         {
@@ -279,16 +298,20 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
     }
     else if (option_size == 14)
     {
+#ifdef SO_SNDBUFFORCE
         if (strncmp("SO_SNDBUFFORCE", option_name, option_size) == 0)
         {
             *option_value = SO_SNDBUFFORCE;
             return 1;
         }
-        else if (strncmp("SO_RCVBUFFORCE", option_name, option_size) == 0)
+#endif
+#ifdef SO_RCVBUFFORCE
+        if (strncmp("SO_RCVBUFFORCE", option_name, option_size) == 0)
         {
             *option_value = SO_RCVBUFFORCE;
             return 1;
         }
+#endif
     }
     else if (option_size == 16)
     {

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -14,11 +14,13 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_IP;
             return 1;
         }
+#ifdef IPPROTO_TP
         if (strncmp("IPPROTO_TP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_TP;
             return 1;
         }
+#endif
         if (strncmp("IPPROTO_AH", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_AH;
@@ -52,21 +54,25 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_IDP;
             return 1;
         }
+#ifdef IPPROTO_GRE
         if (strncmp("IPPROTO_GRE", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_GRE;
             return 1;
         }
+#endif
         if (strncmp("IPPROTO_ESP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_ESP;
             return 1;
         }
+#ifdef IPPROTO_MTP
         if (strncmp("IPPROTO_MTP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_MTP;
             return 1;
         }
+#endif
         if (strncmp("IPPROTO_PIM", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_PIM;
@@ -95,11 +101,13 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_IGMP;
             return 1;
         }
+#ifdef IPPROTO_IPIP
         if (strncmp("IPPROTO_IPIP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_IPIP;
             return 1;
         }
+#endif
 #ifdef IPPROTO_DCCP
         if (strncmp("IPPROTO_DCCP", level_name, level_size) == 0)
         {

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -131,11 +131,13 @@ int level_lookup(char *level_name, int level_size, int *level_value)
     }
     else if (level_size == 14)
     {
+#ifdef IPPROTO_BEETPH
         if (strncmp("IPPROTO_BEETPH", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_BEETPH;
             return 1;
         }
+#endif
     }
     else if (level_size == 15)
     {
@@ -266,12 +268,14 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_BSDCOMPAT;
             return 1;
         }
+#ifdef SO_REUSEPORT
         else if (strncmp("SO_REUSEPORT", option_name, option_size) == 0)
         {
             *option_value = SO_REUSEPORT;
             return 1;
         }
     }
+#endif
     else if (option_size == 14)
     {
         if (strncmp("SO_SNDBUFFORCE", option_name, option_size) == 0)

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -9,17 +9,17 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = SOL_SOCKET;
             return 1;
         }
-        else if (strncmp("IPPROTO_IP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_IP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_IP;
             return 1;
         }
-        else if (strncmp("IPPROTO_TP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_TP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_TP;
             return 1;
         }
-        else if (strncmp("IPPROTO_AH", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_AH", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_AH;
             return 1;
@@ -32,47 +32,47 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_TCP;
             return 1;
         }
-        else if (strncmp("IPPROTO_EGP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_EGP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_EGP;
             return 1;
         }
-        else if (strncmp("IPPROTO_PUP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_PUP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_PUP;
             return 1;
         }
-        else if (strncmp("IPPROTO_UDP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_UDP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_UDP;
             return 1;
         }
-        else if (strncmp("IPPROTO_IDP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_IDP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_IDP;
             return 1;
         }
-        else if (strncmp("IPPROTO_GRE", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_GRE", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_GRE;
             return 1;
         }
-        else if (strncmp("IPPROTO_ESP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_ESP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_ESP;
             return 1;
         }
-        else if (strncmp("IPPROTO_MTP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_MTP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_MTP;
             return 1;
         }
-        else if (strncmp("IPPROTO_PIM", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_PIM", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_PIM;
             return 1;
         }
-        else if (strncmp("IPPROTO_RAW", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_RAW", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_RAW;
             return 1;
@@ -85,41 +85,41 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             *level_value = IPPROTO_IPV6;
             return 1;
         }
-        else if (strncmp("IPPROTO_ICMP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_ICMP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_ICMP;
             return 1;
         }
-        else if (strncmp("IPPROTO_IGMP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_IGMP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_IGMP;
             return 1;
         }
-        else if (strncmp("IPPROTO_IPIP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_IPIP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_IPIP;
             return 1;
         }
 #ifdef IPPROTO_DCCP
-        else if (strncmp("IPPROTO_DCCP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_DCCP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_DCCP;
             return 1;
         }
 #endif
-        else if (strncmp("IPPROTO_RSVP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_RSVP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_RSVP;
             return 1;
         }
 #ifdef IPPROTO_COMP
-        else if (strncmp("IPPROTO_COMP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_COMP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_COMP;
             return 1;
         }
 #endif
-        else if (strncmp("IPPROTO_SCTP", level_name, level_size) == 0)
+        if (strncmp("IPPROTO_SCTP", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_SCTP;
             return 1;
@@ -175,7 +175,7 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_DEBUG;
             return 1;
         }
-        else if (strncmp("SO_ERROR", option_name, option_size) == 0)
+        if (strncmp("SO_ERROR", option_name, option_size) == 0)
         {
             *option_value = SO_ERROR;
             return 1;
@@ -188,12 +188,12 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_SNDBUF;
             return 1;
         }
-        else if (strncmp("SO_RCVBUF", option_name, option_size) == 0)
+        if (strncmp("SO_RCVBUF", option_name, option_size) == 0)
         {
             *option_value = SO_RCVBUF;
             return 1;
         }
-        else if (strncmp("SO_LINGER", option_name, option_size) == 0)
+        if (strncmp("SO_LINGER", option_name, option_size) == 0)
         {
             *option_value = SO_LINGER;
             return 1;
@@ -214,40 +214,40 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
         }
 #endif
 #ifdef SO_PEERCRED
-        else if (strncmp("SO_PEERCRED", option_name, option_size) == 0)
+        if (strncmp("SO_PEERCRED", option_name, option_size) == 0)
         {
             *option_value = SO_PEERCRED;
             return 1;
         }
 #endif
 #ifdef SO_RCVLOAWAT
-        else if (strncmp("SO_RCVLOWAT", option_name, option_size) == 0)
+        if (strncmp("SO_RCVLOWAT", option_name, option_size) == 0)
         {
             *option_value = SO_RCVLOWAT;
             return 1;
         }
 #endif
 #ifdef SO_SNDLOWAT
-        else if (strncmp("SO_SNDLOWAT", option_name, option_size) == 0)
+        if (strncmp("SO_SNDLOWAT", option_name, option_size) == 0)
         {
             *option_value = SO_SNDLOWAT;
             return 1;
         }
 #endif
-        else if (strncmp("SO_RCVTIMEO", option_name, option_size) == 0)
+        if (strncmp("SO_RCVTIMEO", option_name, option_size) == 0)
         {
             *option_value = SO_RCVTIMEO;
             return 1;
         }
 #ifdef SO_NO_CHECK
-        else if (strncmp("SO_NO_CHECK", option_name, option_size) == 0)
+        if (strncmp("SO_NO_CHECK", option_name, option_size) == 0)
         {
             *option_value = SO_NO_CHECK;
             return 1;
         }
 #endif
 #ifdef SO_PRIORITY
-        else if (strncmp("SO_PRIORITY", option_name, option_size) == 0)
+        if (strncmp("SO_PRIORITY", option_name, option_size) == 0)
         {
             *option_value = SO_PRIORITY;
             return 1;
@@ -261,35 +261,35 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_REUSEADDR;
             return 1;
         }
-        else if (strncmp("SO_DONTROUTE", option_name, option_size) == 0)
+        if (strncmp("SO_DONTROUTE", option_name, option_size) == 0)
         {
             *option_value = SO_DONTROUTE;
             return 1;
         }
-        else if (strncmp("SO_BROADCAST", option_name, option_size) == 0)
+        if (strncmp("SO_BROADCAST", option_name, option_size) == 0)
         {
             *option_value = SO_BROADCAST;
             return 1;
         }
-        else if (strncmp("SO_KEEPALIVE", option_name, option_size) == 0)
+        if (strncmp("SO_KEEPALIVE", option_name, option_size) == 0)
         {
             *option_value = SO_KEEPALIVE;
             return 1;
         }
-        else if (strncmp("SO_OOBINLINE", option_name, option_size) == 0)
+        if (strncmp("SO_OOBINLINE", option_name, option_size) == 0)
         {
             *option_value = SO_OOBINLINE;
             return 1;
         }
 #ifdef SO_BSDCOMPAT
-        else if (strncmp("SO_BSDCOMPAT", option_name, option_size) == 0)
+        if (strncmp("SO_BSDCOMPAT", option_name, option_size) == 0)
         {
             *option_value = SO_BSDCOMPAT;
             return 1;
         }
 #endif
 #ifdef SO_REUSEPORT
-        else if (strncmp("SO_REUSEPORT", option_name, option_size) == 0)
+        if (strncmp("SO_REUSEPORT", option_name, option_size) == 0)
         {
             *option_value = SO_REUSEPORT;
             return 1;

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -129,16 +129,17 @@ int level_lookup(char *level_name, int level_size, int *level_value)
             return 1;
         }
     }
+#ifdef IPPROTO_BEETPH
     else if (level_size == 14)
     {
-#ifdef IPPROTO_BEETPH
+
         if (strncmp("IPPROTO_BEETPH", level_name, level_size) == 0)
         {
             *level_value = IPPROTO_BEETPH;
             return 1;
         }
-#endif
     }
+#endif
     else if (level_size == 15)
     {
         if (strncmp("IPPROTO_UDPLITE", level_name, level_size) == 0)
@@ -274,8 +275,8 @@ int optname_lookup(char *option_name, int option_size, int *option_value)
             *option_value = SO_REUSEPORT;
             return 1;
         }
-    }
 #endif
+    }
     else if (option_size == 14)
     {
         if (strncmp("SO_SNDBUFFORCE", option_name, option_size) == 0)

--- a/c_src/sockopt.h
+++ b/c_src/sockopt.h
@@ -1,0 +1,299 @@
+#include <string.h>
+
+int level_lookup(char *level_name, int level_size, int *level_value)
+{
+    if (level_size == 10)
+    {
+        if (strncmp("SOL_SOCKET", level_name, level_size) == 0)
+        {
+            *level_value = SOL_SOCKET;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_IP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_IP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_TP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_TP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_AH", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_AH;
+            return 1;
+        }
+    }
+    else if (level_size == 11)
+    {
+        if (strncmp("IPPROTO_TCP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_TCP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_EGP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_EGP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_PUP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_PUP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_UDP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_UDP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_IDP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_IDP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_GRE", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_GRE;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_ESP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_ESP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_MTP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_MTP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_PIM", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_PIM;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_RAW", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_RAW;
+            return 1;
+        }
+    }
+    else if (level_size == 12)
+    {
+        if (strncmp("IPPROTO_IPV6", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_IPV6;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_ICMP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_ICMP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_IGMP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_IGMP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_IPIP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_IPIP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_DCCP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_DCCP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_RSVP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_RSVP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_COMP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_COMP;
+            return 1;
+        }
+        else if (strncmp("IPPROTO_SCTP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_SCTP;
+            return 1;
+        }
+    }
+    else if (level_size == 13)
+    {
+        if (strncmp("IPPROTO_ENCAP", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_ENCAP;
+            return 1;
+        }
+    }
+    else if (level_size == 14)
+    {
+        if (strncmp("IPPROTO_BEETPH", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_BEETPH;
+            return 1;
+        }
+    }
+    else if (level_size == 15)
+    {
+        if (strncmp("IPPROTO_UDPLITE", level_name, level_size) == 0)
+        {
+            *level_value = IPPROTO_UDPLITE;
+            return 1;
+        }
+    }
+
+    *level_value = -1;
+    return 0;
+}
+
+int optname_lookup(char *option_name, int option_size, int *option_value)
+{
+    if (option_size == 7)
+    {
+        if (strncmp("SO_TYPE", option_name, option_size) == 0)
+        {
+            *option_value = SO_TYPE;
+            return 1;
+        }
+    }
+    else if (option_size == 8)
+    {
+        if (strncmp("SO_DEBUG", option_name, option_size) == 0)
+        {
+            *option_value = SO_DEBUG;
+            return 1;
+        }
+        else if (strncmp("SO_ERROR", option_name, option_size) == 0)
+        {
+            *option_value = SO_ERROR;
+            return 1;
+        }
+    }
+    else if (option_size == 9)
+    {
+        if (strncmp("SO_SNDBUF", option_name, option_size) == 0)
+        {
+            *option_value = SO_SNDBUF;
+            return 1;
+        }
+        else if (strncmp("SO_RCVBUF", option_name, option_size) == 0)
+        {
+            *option_value = SO_RCVBUF;
+            return 1;
+        }
+        else if (strncmp("SO_LINGER", option_name, option_size) == 0)
+        {
+            *option_value = SO_LINGER;
+            return 1;
+        }
+    }
+    else if (option_size == 11)
+    {
+        if (strncmp("SO_PASSCRED", option_name, option_size) == 0)
+        {
+            *option_value = SO_PASSCRED;
+            return 1;
+        }
+        else if (strncmp("SO_PEERCRED", option_name, option_size) == 0)
+        {
+            *option_value = SO_PEERCRED;
+            return 1;
+        }
+        else if (strncmp("SO_RCVLOWAT", option_name, option_size) == 0)
+        {
+            *option_value = SO_RCVLOWAT;
+            return 1;
+        }
+        else if (strncmp("SO_SNDLOWAT", option_name, option_size) == 0)
+        {
+            *option_value = SO_SNDLOWAT;
+            return 1;
+        }
+        else if (strncmp("SO_RCVTIMEO", option_name, option_size) == 0)
+        {
+            *option_value = SO_RCVTIMEO;
+            return 1;
+        }
+        else if (strncmp("SO_SNDTIMEO", option_name, option_size) == 0)
+        {
+            *option_value = SO_SNDTIMEO;
+            return 1;
+        }
+        else if (strncmp("SO_NO_CHECK", option_name, option_size) == 0)
+        {
+            *option_value = SO_NO_CHECK;
+            return 1;
+        }
+        else if (strncmp("SO_PRIORITY", option_name, option_size) == 0)
+        {
+            *option_value = SO_PRIORITY;
+            return 1;
+        }
+    }
+    else if (option_size == 12)
+    {
+        if (strncmp("SO_REUSEADDR", option_name, option_size) == 0)
+        {
+            *option_value = SO_REUSEADDR;
+            return 1;
+        }
+        else if (strncmp("SO_DONTROUTE", option_name, option_size) == 0)
+        {
+            *option_value = SO_DONTROUTE;
+            return 1;
+        }
+        else if (strncmp("SO_BROADCAST", option_name, option_size) == 0)
+        {
+            *option_value = SO_BROADCAST;
+            return 1;
+        }
+        else if (strncmp("SO_KEEPALIVE", option_name, option_size) == 0)
+        {
+            *option_value = SO_KEEPALIVE;
+            return 1;
+        }
+        else if (strncmp("SO_OOBINLINE", option_name, option_size) == 0)
+        {
+            *option_value = SO_OOBINLINE;
+            return 1;
+        }
+        else if (strncmp("SO_BSDCOMPAT", option_name, option_size) == 0)
+        {
+            *option_value = SO_BSDCOMPAT;
+            return 1;
+        }
+        else if (strncmp("SO_REUSEPORT", option_name, option_size) == 0)
+        {
+            *option_value = SO_REUSEPORT;
+            return 1;
+        }
+    }
+    else if (option_size == 14)
+    {
+        if (strncmp("SO_SNDBUFFORCE", option_name, option_size) == 0)
+        {
+            *option_value = SO_SNDBUFFORCE;
+            return 1;
+        }
+        else if (strncmp("SO_RCVBUFFORCE", option_name, option_size) == 0)
+        {
+            *option_value = SO_RCVBUFFORCE;
+            return 1;
+        }
+    }
+    else if (option_size == 16)
+    {
+        if (strncmp("IPV6_RECVPKTINFO", option_name, option_size) == 0)
+        {
+            *option_value = IPV6_RECVPKTINFO;
+            return 1;
+        }
+    }
+
+    *option_value = -1;
+    return 0;
+}


### PR DESCRIPTION
This PR provides an optional way for applications to specify the `level` and `option_name` parameters to `setsockopt` and `getsockopt` as atoms representing the names of the OS-level defines. It shifts the burden of cross-platform compatability for those function calls from the application to the procket library. 

The motivation for this comes from trying to get our application that uses procket to build on SmartOS in addition to Linux. We also have some developers who use OSX who would like the application to build in their local development environment. We have an ugly case statement to set the `level` and `option_name` values we need for each OS, but that is brittle and it is something better done once by the library than by each application using the library. 

We have this branch successfully building on Arch Linux, Debian 7, SmartOS, and OSX. The set of supported levels and option names is not exhaustive, but we felt it was a good start and could be easily extended to meet other users' needs. The existing interface is not broken by the change so existing applications will still work without change.