### PR TITLE
Use rand:uniform instead of crypto:rand_unfiform

### DIFF
--- a/src/procket_mktmp.erl
+++ b/src/procket_mktmp.erl
@@ -60,7 +60,7 @@ template(Name, Chars) ->
     template(lists:reverse(Name), [], Chars).
 template([$X|Rest], Acc, Chars) ->
     template(Rest,
-        [lists:nth(crypto:rand_uniform(1, length(Chars)+1), Chars)|Acc],
+        [lists:nth(rand:uniform(length(Chars)+1), Chars)|Acc],
         Chars);
 template(Name, Rand, _) when length(Rand) >= 6 ->
     lists:reverse(Name) ++ Rand.


### PR DESCRIPTION
crypto:rand_bytes/2 is deprecated is new Erlang releases and should be replaced with rand:uniform/1 