### PR TITLE
Add support for crosscompiling procket.so

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -4,15 +4,17 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
-ERLANG_ARCH ?= $(shell erl -noshell -s init stop -eval "io:format(\"~B\", [erlang:system_info({wordsize,external}) * 8]).")
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 
 # System type and C compiler/flags.
+
+ifeq ($(CROSSCOMPILE),)
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERLANG_ARCH ?= $(shell erl -noshell -s init stop -eval "io:format(\"~B\", [erlang:system_info({wordsize,external}) * 8]).")
 
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
@@ -43,6 +45,7 @@ else ifeq ($(UNAME_ARCH), i686)
 else ifeq ($(UNAME_ARCH), i386)
 	PROCKET_CFLAGS += -m$(ERLANG_ARCH)
 	CFLAGS += -m$(ERLANG_ARCH)
+endif
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)


### PR DESCRIPTION
When crosscompiling, this change skips the code that interrogates the
host for compilation options. Since it isn't easy to detect the right
options for the crosscompile case, the Makefile expects the user to have
defined $(CC), $(ERTS_INCLUDE_DIR), $(ERL_INTERFACE_INCLUDE_DIR) and
several other variables. Luckily, this is done automatically by at least
a couple build systems that are aware of crosscompiling Erlang projects.

The existing code almost worked for the crosscompile case except for
wordsize detection.  This change skips this and all of the detection logic
to avoid any chance of intermingling target and host options.

Crosscompile detection is done by looking for the
$(CROSSCOMPILE) variable since it is usually set as well when
crosscompiling.

This change was verified by compiling and using procket on a
Nerves-based project.