### PR TITLE
Add set sock o_nonblock nif

### DIFF
--- a/c_src/procket.c
+++ b/c_src/procket.c
@@ -1177,6 +1177,29 @@ procket_alloc_free(ErlNifEnv *env, void *obj)
 }
 
 
+    static ERL_NIF_TERM
+nif_set_sock_nonblock(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    int s = -1;
+    int flags = 0;
+
+    if (!enif_get_int(env, argv[0], &s))
+        return enif_make_badarg(env);
+
+    if (s < 0)
+        return error_tuple(env, errno);
+
+    flags = fcntl(s, F_GETFL, 0);
+
+    if (flags < 0)
+        return error_tuple(env, errno);
+
+    if (fcntl(s, F_SETFL, flags|O_NONBLOCK) < 0)
+        return error_tuple(env, errno);
+
+    return atom_ok;
+}
+
 static ErlNifFunc nif_funcs[] = {
     {"fdrecv", 1, nif_fdrecv},
 
@@ -1213,7 +1236,9 @@ static ErlNifFunc nif_funcs[] = {
     {"socket_optname", 1, nif_socket_optname},
     {"socket_protocol", 1, nif_socket_protocol},
 
-    {"errno_id", 1, nif_errno_id}
+    {"errno_id", 1, nif_errno_id},
+
+    {"set_sock_nonblock", 1, nif_set_sock_nonblock}
 };
 
 ERL_NIF_INIT(procket, nif_funcs, load, reload, upgrade, NULL)

--- a/src/procket.erl
+++ b/src/procket.erl
@@ -66,7 +66,9 @@
         socket_optname/0, socket_optname/1,
         socket_protocol/0, socket_protocol/1,
 
-        errno_id/1
+        errno_id/1,
+        
+        set_sock_nonblock/1
     ]).
 -export([
         unix_path_max/0,
@@ -289,6 +291,9 @@ socket_protocol(_) ->
     erlang:nif_error(not_implemented).
 
 errno_id(_) ->
+    erlang:nif_error(not_implemented).
+
+set_sock_nonblock(_) ->
     erlang:nif_error(not_implemented).
 
 socket_constant_foreach(_Constant, []) ->


### PR DESCRIPTION
This PR add a nif to set a socket non blocking.

I'm using procket in combination with `erlang:open_port/2` and `erlang:port_close/1`.
I'm polling the socket like here https://github.com/msantos/inert#busy-waiting
but instead of sleep and spin again on `{error, eagain}` I pass in active mode with `erlang:open_port/2` and then after receiving a pkt I switch back to passive mode with `erlang:port_close/1`. 
The problem is that when you use `port_close` the socket is set as `BLOCKING` and a call to `procket:read/2` blocks until new data arrive.