### PR TITLE
Remove arch to support darwin on m1

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -17,9 +17,9 @@ ERLANG_ARCH ?= $(shell erl -noshell -s init stop -eval "io:format(\"~B\", [erlan
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
@@ -35,6 +35,9 @@ endif
 
 UNAME_ARCH := $(shell uname -m)
 ifeq ($(UNAME_ARCH), x86_64)
+	PROCKET_CFLAGS += -m$(ERLANG_ARCH)
+	CFLAGS += -m$(ERLANG_ARCH)
+else ifeq ($(UNAME_ARCH), arm64)
 	PROCKET_CFLAGS += -m$(ERLANG_ARCH)
 	CFLAGS += -m$(ERLANG_ARCH)
 else ifeq ($(UNAME_ARCH), i686)


### PR DESCRIPTION
This change was useful when trying to compile on an M1 mac.

Similar: https://github.com/msantos/inert/pull/9