### PR TITLE
Use erlang halt vs init stop in Makefile

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -11,8 +11,8 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 # System type and C compiler/flags.
 
 ifeq ($(CROSSCOMPILE),)
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERLANG_ARCH ?= $(shell erl -noshell -s init stop -eval "io:format(\"~B\", [erlang:system_info({wordsize,external}) * 8]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
+ERLANG_ARCH ?= $(shell erl -noshell -eval "io:format(\"~B\", [erlang:system_info({wordsize,external}) * 8])." -s erlang halt)
 
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)


### PR DESCRIPTION
In Erlang/OTP 26 a race condition was uncovered when using `-eval` with `-s init stop` (i.e., it was always there, but most of the community lucked out in not running into it). 

See https://github.com/erlang/otp/issues/6916 for details