### PR TITLE
FreeBSD AF_NETLINK is defined as 38

### DIFF
--- a/src/procket.erl
+++ b/src/procket.erl
@@ -524,7 +524,10 @@ family(inet6) ->
         {unix, sunos} -> 26
     end;
 family(netlink) ->
-    16;
+    case os:type() of
+        {unix, linux} -> 16;
+        {unix, freebsd} -> 38
+    end;
 family(packet) ->
     17;
 family(Proto) when Proto == local; Proto == unix; Proto == file -> 1.


### PR DESCRIPTION
FreeBSD (has netlink protocol support since 13.2 - released April 2023) uses 38 for AF_NETLINK.