### PR TITLE
Add support for setting IPV6_V6ONLY option in procket:open/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ open(Port, Options) -> {ok, FD} | {error, posix()}
                 | {interface, string()}
                 | {pipe, string()}
                 | {namespace, string()}
+                | {ipv6_v6only, boolean()}
             Protocol = protocol() | integer()
             Type = type() | integer()
             Family = family() | integer()

--- a/c_src/procket.h
+++ b/c_src/procket.h
@@ -89,4 +89,5 @@ typedef struct {
     int type;               /* socket type: SOCK_STREAM */
     int protocol;           /* socket protocol: IPPROTO_TCP */
     int backlog;            /* Listen backlog */
+    int v6only;             /* IPV6_V6ONLY socket option */
 } PROCKET_STATE;

--- a/c_src/procket_cmd.c
+++ b/c_src/procket_cmd.c
@@ -74,19 +74,34 @@ int main(int argc, char *argv[]) {
     case 'b': /* listen backlog */
       ps->backlog = atoi(optarg);
       break;
+    case 'd': /* Open a character device */
+      ps->dev = strdup(optarg);
+
+     if (ps->dev == NULL)
+        error_result(ps, errno);
+
+      if (procket_check_devname(ps->dev, 32) < 0)
+        usage(ps);
+
+      ps->fdtype = PROCKET_FD_CHARDEV;
+      break;
     case 'F': /* socket family/domain */
       ps->family = atoi(optarg);
       break;
-    case 'u': /* path to Unix socket */
-      ps->path = strdup(optarg);
+    case 'I': /* Interface name */
+      ps->ifname = strdup(optarg);
 
-      if (ps->path == NULL)
+      if (ps->ifname == NULL)
         error_result(ps, errno);
 
-      ps->pathlen = strlen(ps->path);
-
-      if (ps->pathlen >= UNIX_PATH_MAX)
+      if (strlen(ps->ifname) >= IFNAMSIZ)
         error_result(ps, ENAMETOOLONG);
+      break;
+    case 'N': /* namespace */
+      ps->ns = strdup(optarg);
+
+      if (ps->ns == NULL)
+        error_result(ps, errno);
       break;
     case 'p': /* port */
       ps->port = strdup(optarg);
@@ -103,31 +118,16 @@ int main(int argc, char *argv[]) {
     case 'T': /* socket type */
       ps->type = atoi(optarg);
       break;
-    case 'I': /* Interface name */
-      ps->ifname = strdup(optarg);
+    case 'u': /* path to Unix socket */
+      ps->path = strdup(optarg);
 
-      if (ps->ifname == NULL)
+      if (ps->path == NULL)
         error_result(ps, errno);
 
-      if (strlen(ps->ifname) >= IFNAMSIZ)
+      ps->pathlen = strlen(ps->path);
+
+      if (ps->pathlen >= UNIX_PATH_MAX)
         error_result(ps, ENAMETOOLONG);
-      break;
-    case 'd': /* Open a character device */
-      ps->dev = strdup(optarg);
-
-      if (ps->dev == NULL)
-        error_result(ps, errno);
-
-      if (procket_check_devname(ps->dev, 32) < 0)
-        usage(ps);
-
-      ps->fdtype = PROCKET_FD_CHARDEV;
-      break;
-    case 'N': /* namespace */
-      ps->ns = strdup(optarg);
-
-      if (ps->ns == NULL)
-        error_result(ps, errno);
       break;
     case 'v':
       ps->verbose++;
@@ -456,15 +456,17 @@ void usage(PROCKET_STATE *ps) {
       stderr,
       "usage: %s <options> <ipaddress>\n"
       "              -b <backlog>     listen socket backlog [default:%d]\n"
-      "              -u <path>        path to Unix socket\n"
-      "              -p <port>        port\n"
+      "              -d <name>        open device\n"
       "              -F <family>      family [default: PF_UNSPEC]\n"
-      "              -P <protocol>    protocol [default: IPPROTO_TCP]\n"
-      "              -T <type>        type [default: SOCK_STREAM]\n"
+      "              -h               display this help text\n"
 #ifdef SO_BINDTODEVICE
       "              -I <name>        interface [default: ANY]\n"
 #endif
-      "              -d <name>        open device\n"
+      "              -N <namespace>   Linux namespace to open the socket in\n"
+      "              -p <port>        port\n"
+      "              -P <protocol>    protocol [default: IPPROTO_TCP]\n"
+      "              -T <type>        type [default: SOCK_STREAM]\n"
+      "              -u <path>        path to Unix socket\n"
       "              -v               verbose mode\n",
       __progname, BACKLOG);
 

--- a/src/procket.erl
+++ b/src/procket.erl
@@ -338,7 +338,8 @@
     | {progname, string()}
     | {interface, string()}
     | {pipe, string()}
-    | {namespace, string()}.
+    | {namespace, string()}
+    | {ipv6_v6only, boolean()}.
 
 -export_type([
     uint16_t/0,
@@ -1332,6 +1333,13 @@ optarg({dev, Dev}) when is_list(Dev) ->
     end;
 optarg({namespace, NS}) when is_list(NS) ->
     switch("N", NS);
+optarg({ipv6_v6only, Bool}) when is_boolean(Bool) ->
+    case Bool of
+        true ->
+            switch("O", 1);
+        false ->
+            switch("O", 0)
+    end;
 % Ignore any other arguments
 optarg(_Arg) ->
     "".


### PR DESCRIPTION
On some operating systems, opening a socket and having it listen on the IPv6 unspecified address (::) will silently open a dual-stack socket, listening both for IPv4 and IPv6 connections. On Linux, this is often the default, although this behavior can be controlled by the `sys.net.ipv6.bindv6only` sysctl.

However, some applications may want to ensure that IPv6 sockets always listen to IPv6 connections *only*, e.g. for portability reasons. For example, a server program may ship with a configuration example that has it listen on IPv4 and IPv6 on all interfaces. According to whether IPv6 sockets are single- or dual-stack, this configuration example may fail on some hosts – usually with an error like “address already in use”. The easiest way to write a dual-stack server portably is to have it create one socket per address family, and to set the IPV6_V6ONLY socket option to 1 with setsockopt(2) right after creating the IPv6 socket.

This pull request adds the `ipv6_v6only` option to `procket:open/2` and the corresponding `-O` command-line option in the procket binary. If left unspecified, procket will use the OS environment’s default behavior regarding dual-stack IPv6 sockets. If explicitly set to true or false, procket will call setsockopt(2) to set IPV6_V6ONLY to 1 or 0 respectively.

I also used that opportunity to sort command-line options alphabetically in two places in `procket.c`, because the number of options has grown to a point where I think it would be nicer to sort them.

See also: [ipv6(7)](https://www.man7.org/linux/man-pages/man7/ipv6.7.html) on Linux or [ip6(4)](https://man.freebsd.org/cgi/man.cgi?query=ip6&sektion=4&apropos=0&manpath=FreeBSD+14.3-RELEASE+and+Ports) on FreeBSD.